### PR TITLE
fix(tiler): packaged import for resolve_aoi in region splits

### DIFF
--- a/geoai_datacubes/preprocessing/tiler.py
+++ b/geoai_datacubes/preprocessing/tiler.py
@@ -568,7 +568,7 @@ def _resolve_region_specs(spec_dict):
         if isinstance(spec, (list, tuple)) and len(spec) == 4:
             out[name] = [float(v) for v in spec]
         elif isinstance(spec, dict):
-            from aoi import resolve_aoi
+            from ..fetch.aoi import resolve_aoi
             out[name] = resolve_aoi(spec)
         else:
             raise ValueError(

--- a/tests/test_tiler_regions.py
+++ b/tests/test_tiler_regions.py
@@ -1,0 +1,40 @@
+"""Regression tests for ``split_regions`` AOI-dict resolution in the tiler.
+
+Guards against the stale ``from aoi import resolve_aoi`` absolute import that
+raised ``ModuleNotFoundError`` whenever a region was passed as an AOI spec dict
+(only raw 4-element bbox lists survived). See ``_resolve_region_specs``.
+"""
+import pytest
+
+from geoai_datacubes.preprocessing.tiler import _resolve_region_specs
+
+
+def test_region_specs_accept_bbox_lists():
+    bbox = [-83.10, 39.95, -82.95, 40.05]
+    out = _resolve_region_specs({"train": bbox})
+    assert out["train"] == [float(x) for x in bbox]
+
+
+def test_region_specs_resolve_aoi_dict():
+    # An AOI *dict* (not a raw bbox) used to crash with ModuleNotFoundError
+    # because tiler.py imported the top-level ``aoi`` module instead of the
+    # packaged ``geoai_datacubes.fetch.aoi``.
+    specs = {
+        "train": {"bbox": [-83.10, 39.95, -82.95, 40.05]},
+        "val": {"center": (40.0067, -83.0305), "side_miles": 2},
+    }
+    out = _resolve_region_specs(specs)
+    assert set(out) == {"train", "val"}
+    for name, box in out.items():
+        lon_min, lat_min, lon_max, lat_max = box
+        assert lon_min < lon_max and lat_min < lat_max
+
+
+def test_region_specs_reject_unknown_split_name():
+    with pytest.raises(ValueError, match="must be one of"):
+        _resolve_region_specs({"holdout": [-83.10, 39.95, -82.95, 40.05]})
+
+
+def test_region_specs_reject_bad_spec_type():
+    with pytest.raises(ValueError, match="bbox list"):
+        _resolve_region_specs({"train": "not-a-spec"})


### PR DESCRIPTION
Fixes a `ModuleNotFoundError` in `split_regions` when a split is given as an AOI **spec dict** rather than a raw bbox list.

### Problem
`_resolve_region_specs` in `geoai_datacubes/preprocessing/tiler.py` imported the top-level `aoi` module:

```python
from aoi import resolve_aoi
```

That module is not importable from an installed package, so any `split_regions` entry passed as an AOI dict (e.g. `{"center": (...), "side_miles": 2}` or `{"bbox": [...]}`) crashed. Only raw 4-element bbox lists survived.

### Fix
Use the packaged relative import, matching `fetch/__init__.py` and `fetch/parallel_fetch.py`:

```python
from ..fetch.aoi import resolve_aoi
```

### Tests
Adds `tests/test_tiler_regions.py` (no prior coverage of this path):
- bbox-list passthrough
- AOI-dict resolution (`bbox` and `center`/`side_miles`) — the previously-crashing case
- unknown split-name rejected
- bad spec-type rejected

Verified locally that `_resolve_region_specs` resolves AOI dicts without the import error.