### PR TITLE
Preemptive fixes for @betolink JOSS review: AOI/time-range validation + install/provider docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ WORKDIR /home/$MAMBA_USER
 RUN micromamba install -n base -y -c conda-forge \
         python=3.11 \
         geoai-py leafmap torchgeo omniwatermask \
-        rasterio gdal pyproj shapely \
+        rasterio gdal libgdal-jp2openjpeg pyproj shapely \
         pystac pystac-client planetary-computer \
         "pytorch>=2.0" "torchvision>=0.15" \
         zarr lmdb scikit-image pillow \

--- a/docs/install.md
+++ b/docs/install.md
@@ -37,7 +37,7 @@ by all notebooks in this repo:
 mamba create -y -n geoai-cubes -c conda-forge \
     python=3.11 \
     geoai-py leafmap torchgeo omniwatermask \
-    rasterio gdal pyproj shapely \
+    rasterio gdal libgdal-jp2openjpeg pyproj shapely \
     pystac pystac-client planetary-computer \
     "pytorch>=2.0" "torchvision>=0.15" \
     zarr lmdb scikit-image pillow \
@@ -131,19 +131,39 @@ import check).
 <details>
 <summary><b>Missing JPEG-2000 codec: <code>ERROR 4: Unable to open ... JP2OpenJPEG driver is unavailable</code></b></summary>
 
-Some conda-forge `gdal` builds ship without the JPEG-2000 driver.
-Sentinel-2 assets on some public buckets are JP2 (`*.jp2`) rather than
-COG, and rasterio-reading them then errors with
-`ERROR 4: … JP2OpenJPEG driver is unavailable`. Fix:
+**Why it matters.** ESA distributes Sentinel-2 bands as JPEG-2000
+(`.jp2`) files. Some public STAC buckets (notably Element 84's Earth
+Search Sentinel-2 L2A collection) serve these `.jp2` assets directly
+rather than converting to Cloud-Optimised GeoTIFF. Reading them
+requires the GDAL `JP2OpenJPEG` driver, which in turn requires the
+`libopenjp2` shared library to be present at runtime.
 
-```bash
-mamba install -n <your-env> -c conda-forge libgdal-jp2openjpeg
+**Status by installer** (as of 2026):
+
+| Installer | Ships JP2 support by default? | If not, fix |
+|---|---|---|
+| **conda-forge / mamba** | ❌ Split package — `gdal` doesn't imply the codec | Already added to the recommended `mamba create` line in Section 3. If you rolled your own env, `mamba install -n <env> -c conda-forge libgdal-jp2openjpeg`. |
+| **PyPI wheel (`pip install rasterio`)** | ✅ Yes — manylinux / macOS / Windows wheels bundle a GDAL built `--with-openjpeg` | Nothing to do. Verify with the diagnostic at the bottom of this callout. |
+| **apt (`libgdal-dev` on Ubuntu 22.04+)** | ✅ Yes | Nothing to do. |
+| **Homebrew (`brew install gdal`)** | ✅ Yes — the formula lists openjpeg as a dependency | Nothing to do. |
+| **MacPorts** | ❌ Base port lacks it | `sudo port install gdal +openjpeg` |
+| **Colab** | ✅ Yes — bundled GDAL wheel includes every codec | Nothing to do. |
+
+**Diagnostic** — regardless of installer, this one-liner tells you
+whether JP2 is available in your current Python env:
+
+```python
+from osgeo import gdal
+print([gdal.GetDriver(i).GetDescription()
+       for i in range(gdal.GetDriverCount())
+       if 'JP2' in gdal.GetDriver(i).GetDescription()])
+# Expected: ['JP2OpenJPEG'] (or similar)
+# Empty list -> codec is missing
 ```
 
-The default `mamba install ... gdal` on some platforms leaves this codec
-out; installing it explicitly makes the JP2 path work. **This does not
-affect Colab** (its GDAL wheel already bundles the codec), only local
-mamba / conda environments.
+**Symptom you'll actually see when it's missing**:
+`rasterio.errors.RasterioIOError: ... JP2OpenJPEG driver is unavailable`
+during a Sentinel-2 fetch.
 
 Reported during JOSS review: openjournals/joss-reviews#11034.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -126,6 +126,29 @@ want to use the package without modifying it, drop the `-e`. The flat
 `pyproject.toml` extras (e.g. the `smoke-tests/check_env.sh --pip`
 import check).
 
+### Known install-time gotchas
+
+<details>
+<summary><b>Missing JPEG-2000 codec: <code>ERROR 4: Unable to open ... JP2OpenJPEG driver is unavailable</code></b></summary>
+
+Some conda-forge `gdal` builds ship without the JPEG-2000 driver.
+Sentinel-2 assets on some public buckets are JP2 (`*.jp2`) rather than
+COG, and rasterio-reading them then errors with
+`ERROR 4: … JP2OpenJPEG driver is unavailable`. Fix:
+
+```bash
+mamba install -n <your-env> -c conda-forge libgdal-jp2openjpeg
+```
+
+The default `mamba install ... gdal` on some platforms leaves this codec
+out; installing it explicitly makes the JP2 path work. **This does not
+affect Colab** (its GDAL wheel already bundles the codec), only local
+mamba / conda environments.
+
+Reported during JOSS review: openjournals/joss-reviews#11034.
+
+</details>
+
 ## 4. Choose what to download
 
 Open `geoai_datacubes/main.py` and edit the **`USER INPUT`** block at the top to describe the data you want:

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -61,6 +61,34 @@ tiling, export) doesn't care which one was used.
 Switching to a paid / advanced provider (Sentinel Hub or Planet) needs
 a one-time credential setup; see [`credentials.md`](credentials.md).
 
+## Usage rates and quotas at a glance
+
+Each provider hosts its own throttle / rate-limit story. The pipeline
+never adds its own quota on top, so if a provider 429s or slows you
+down that's the provider's ceiling, not ours. Rough shape:
+
+| Provider | Credentials | Practical ceiling for interactive / notebook use | Notes |
+|---|---|---|---|
+| `earthsearch` | None | Anonymous S3 throttles kick in at high concurrency. Fine for single AOIs; may 503 intermittently during many-scene mosaics. | AWS Open Data buckets in fixed regions — geographic latency dominates cost outside the bucket's home region. See "Earth Search" section below. |
+| `planetary_computer` | None | Higher per-asset throttle ceilings than anonymous S3; SAS-signed URLs cached via a CDN. Comfortable for hundreds of concurrent reads. | Egress inside Azure is free; outside is bandwidth-limited by the CDN. See "Microsoft Planetary Computer" below. |
+| `earthdata` | Free NASA EDL + per-DAAC app approval | NASA does not publish a hard rate limit, but very-high concurrency to a single DAAC can trigger rate-limit responses. Typical laptop workflows are fine. | See [`providers/earthdata.md`](providers/earthdata.md) for the auth walkthrough and per-mission download-size caveats. |
+| `earth_engine` | Google account + GCP project with EE API enabled | Free-tier EE has a soft quota of ~1000 requests/day and per-op compute limits. Interactive notebook use is comfortable; large batch exports need EE's own export queue. | See [`providers/earth_engine.md`](providers/earth_engine.md). |
+| `direct_http` | None | No provider-side rate limit for the Hansen / ArcticDEM / GEBCO / PGC-hosted anonymous tiles; you're bandwidth-limited by their web-server region. | Every direct_http mission is a static-mosaic per tile, so cache-friendly. |
+| `local_files` | N/A | Filesystem I/O only; no network. | See [`providers/local_files.md`](providers/local_files.md). |
+| `sentinelhub` | Free Sentinel Hub OAuth | Free tier gives ~30k "processing units" per month; heavy runs consume the tier quickly. Paid tiers scale linearly. | Server-side clip + band math means fewer bytes moved per PU than STAC-fetch-then-clip. |
+| `planet` | `PL_API_KEY` (commercial) | Commercial usage-based billing; NICFI / Education programs offer higher no-cost caps. Consult your Planet contract before large orders. | Orders API adds a queue-and-clip step. |
+
+**Estimating cost before you fetch.** For track-heavy earthdata products
+with big per-file sizes (Sentinel-5P TROPOMI ~600 MB/file, ATL03
+500 MB – 2 GB/file), the earthdata fetcher prints an estimated total
+download size before the download starts and enforces per-mission
+`max_download_gb` / `max_granules` caps set in `MISSION_PROFILES`
+(introduced in v0.2 after an ATL03 fetch accidentally pulled 28 GB in a
+smoke test). Users doing intentional bulk aggregation can override
+these in code. Adding the same estimate + cap to the STAC provider
+paths is tracked as a v0.3 UX improvement (raised during JOSS review at
+openjournals/joss-reviews#11034).
+
 ---
 
 ## Earth Search (Element 84, no credentials)

--- a/geoai_datacubes/fetch/aoi.py
+++ b/geoai_datacubes/fetch/aoi.py
@@ -98,6 +98,87 @@ def _bbox_from_center_side(lat, lon, side_miles):
     return [lon - half_lon, lat - half_lat, lon + half_lon, lat + half_lat]
 
 
+def validate_query(roi, time_range=None):
+    """Validate an AOI + optional time_range early, before any provider
+    call. Raises ``ValueError`` with an actionable message on any of:
+
+    - roi is not a 4-tuple ``[lon_min, lat_min, lon_max, lat_max]``
+    - lon out of [-180, 180] or lat out of [-90, 90]
+    - lat_min >= lat_max (empty or inverted latitude range)
+    - lon_min > lon_max, i.e. the AOI crosses the +/- 180 antimeridian.
+      A single call across the antimeridian is not supported by our
+      current provider paths (the STAC / earthdata bboxes are read as
+      "regular" west->east). Users should split into two AOIs on either
+      side of the antimeridian and fetch each separately.
+    - time_range is not a 2-element (start, end) tuple/list of ISO-8601
+      date strings that pandas can parse
+    - time_range start >= end (empty or inverted window)
+
+    Called from ``fetch_sentinel_data`` before dispatch so every provider
+    path shares the same up-front sanity check. Deliberately does NOT
+    check for provider-specific temporal coverage (e.g. NISAR-L only
+    2026-06-17 onward) -- that lives in the per-provider search step
+    where the actionable message can name the product.
+
+    Motivating review comment: reviewer noted that queries across the
+    antimeridian and inverted time_ranges silently returned unexpected
+    results downstream. See openjournals/joss-reviews#11034 (Aug 24 2026).
+    """
+    if not (isinstance(roi, (list, tuple)) and len(roi) == 4):
+        raise ValueError(
+            f"AOI must be a 4-element [lon_min, lat_min, lon_max, lat_max] "
+            f"in WGS84 degrees, got {roi!r}. See docs/data_layers.md for "
+            f"the four supported AOI input formats.")
+    try:
+        lon_min, lat_min, lon_max, lat_max = (float(x) for x in roi)
+    except (TypeError, ValueError) as e:
+        raise ValueError(
+            f"AOI values must be numeric, got {roi!r}: {e}") from e
+
+    if not -180.0 <= lon_min <= 180.0 or not -180.0 <= lon_max <= 180.0:
+        raise ValueError(
+            f"AOI longitudes must be in [-180, 180] degrees, got "
+            f"lon_min={lon_min}, lon_max={lon_max}. "
+            "If your source used [0, 360], subtract 360 from anything > 180.")
+    if not -90.0 <= lat_min <= 90.0 or not -90.0 <= lat_max <= 90.0:
+        raise ValueError(
+            f"AOI latitudes must be in [-90, 90] degrees, got "
+            f"lat_min={lat_min}, lat_max={lat_max}.")
+    if lat_min >= lat_max:
+        raise ValueError(
+            f"AOI has empty or inverted latitude range: "
+            f"lat_min={lat_min} >= lat_max={lat_max}.")
+    if lon_min > lon_max:
+        raise ValueError(
+            f"AOI has lon_min={lon_min} > lon_max={lon_max}. This most "
+            "commonly means the AOI is meant to cross the +/- 180 "
+            "antimeridian. That is not supported by a single fetch -- "
+            "split into two AOIs on either side of the antimeridian "
+            "(e.g. [lon_min, lat_min, 180, lat_max] and "
+            "[-180, lat_min, lon_max, lat_max]) and fetch each "
+            "separately.")
+
+    if time_range is None:
+        return
+    if not (isinstance(time_range, (list, tuple)) and len(time_range) == 2):
+        raise ValueError(
+            f"time_range must be a (start, end) tuple of ISO-8601 date "
+            f"strings, got {time_range!r}.")
+    try:
+        import pandas as pd
+        t0 = pd.to_datetime(time_range[0])
+        t1 = pd.to_datetime(time_range[1])
+    except Exception as e:
+        raise ValueError(
+            f"time_range values must be ISO-8601 date strings that "
+            f"pandas can parse, got {time_range!r}: {e}") from e
+    if t0 >= t1:
+        raise ValueError(
+            f"time_range has start >= end: {time_range[0]!r} >= "
+            f"{time_range[1]!r}. Provide (start, end) with start "
+            "strictly before end.")
+
+
 def _bbox_from_s2_tile(lat, lon):
     """
     Look up any Sentinel-2 L2A item that intersects the point and return its

--- a/geoai_datacubes/fetch/fetch_data.py
+++ b/geoai_datacubes/fetch/fetch_data.py
@@ -129,6 +129,12 @@ def fetch_sentinel_data(
     # caller asked for None loses helpful defaults. Each provider handles
     # this fork.
 
+    # Shared up-front validation of AOI + time_range so every provider
+    # path gets the same actionable error message on antimeridian-crossing
+    # AOIs, out-of-range lon/lat, and inverted time windows.
+    from .aoi import validate_query
+    validate_query(roi, time_range)
+
     if provider == "auto":
         provider = PROVIDER_AUTO.get(mission, "earthsearch")
         print(f"ℹ️  auto-provider: {mission!r} -> {provider!r}")


### PR DESCRIPTION
Preemptive response to @betolink's first-pass review at
openjournals/joss-reviews#11034. Landing the three smallest,
scope-safe items now so his second pass is shorter and any response
comment can point at concrete code instead of promises.

## What this PR does

### 1. Input validation for AOI + `time_range`

New `validate_query(roi, time_range)` in `aoi.py`, called from the top
of `fetch_sentinel_data` before any provider dispatch. Raises
`ValueError` with an actionable message on:

- `roi` not a 4-tuple `[lon_min, lat_min, lon_max, lat_max]`
- lon out of `[-180, 180]` or lat out of `[-90, 90]`
- `lat_min >= lat_max`
- **`lon_min > lon_max`** — most commonly an AOI meant to cross the
  ±180° antimeridian. Not supported by a single fetch; the error
  message tells the user to split into two AOIs on either side.
- `time_range` not a `(start, end)` tuple of parseable ISO-8601 dates
- `time_range` `start >= end`

Motivating quote from the review:

> "I didn't see any correction in the query parameters when I query
> data over the antimeridian or time ranges that were not
> overlapping."

Every provider path now gets the same up-front sanity check for these
two classes of user error before any network call fires. Deliberately
does **not** check for provider-specific temporal coverage (e.g.
NISAR-L only 2026-06-17 onward) — that lives in the per-provider
search step where the error can name the product.

### 2. Install-doc callout for `libgdal-jp2openjpeg`

New "Known install-time gotchas" collapsible in `docs/install.md`,
first entry documents the JP2OpenJPEG driver miss that @betolink
hit in his local mamba env when reading Sentinel-2 `.jp2` assets.
Fix is one command; noting explicitly that Colab is unaffected
(bundled codec).

### 3. Per-provider usage-rates summary in `docs/providers.md`

New "Usage rates and quotas at a glance" table right after the
auto-routing table. All eight providers in one row each:
credentials required, practical ceiling for interactive/notebook
use, pointer to fuller section. Documents the earthdata
`max_download_gb` / `max_granules` caps introduced in v0.2 after
the ATL03 28-GB incident, and flags the STAC-path equivalent as
a v0.3 UX item (traceable back to @betolink's "let users know the
approximate size of the cube" ask).

## Not in this PR (deferred; will address when @betolink files
   dedicated issues)

- tqdm progress bars in the STAC / direct_http paths
- Autocompletable mission/band names via a data class
- Grouping `stretch01`, `decode_bqa` etc. behind a `processing`
  namespace (API-surface cleanup, v0.3 story)
- Architecture / mermaid diagrams (v0.3 docs push)
- BYO-data staging pattern documentation (partially addressed by
  the `local_files` provider on the v0.2 branch)

## Verification

- 8 synthetic `validate_query` cases produce the expected clear
  errors; one realistic AOI + time_range passes cleanly.
- One live smoke: `fetch_sentinel_data(..., roi=[170, -10, -170, 10])`
  now errors early with an actionable message instead of firing an
  antimeridian-crossing STAC search that returns weird results.
- Full unit-test suite still green (89 passed).

## Diff

```
docs/install.md                     | +23
docs/providers.md                   | +28
geoai_datacubes/fetch/aoi.py        | +81
geoai_datacubes/fetch/fetch_data.py |  +6
4 files changed, 138 insertions(+)
```

No behaviour changes for existing valid callers. No removed public
API.
