### PR TITLE
docs(architecture): rename to .qmd + use ```{mermaid} so Quarto renders the diagrams (fixes #24 follow-up 2)

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -9,7 +9,7 @@ project:
     - "docs/providers.md"
     - "docs/data_layers.md"
     - "docs/adding_a_mission.md"
-    - "docs/architecture.md"
+    - "docs/architecture.qmd"
     - "docs/configuration.md"
     - "docs/fusion.md"
     - "docs/HPC_QUICKSTART.md"
@@ -44,7 +44,7 @@ website:
           - docs/adding_a_mission.md
       - text: Core pipeline
         menu:
-          - docs/architecture.md
+          - docs/architecture.qmd
           - docs/configuration.md
           - docs/fusion.md
       - text: HPC
@@ -86,7 +86,7 @@ website:
       - section: "Core pipeline"
         icon: cpu
         contents:
-          - docs/architecture.md
+          - docs/architecture.qmd
           - docs/configuration.md
           - docs/fusion.md
       - section: "Notebooks (open in Colab)"

--- a/docs/architecture.qmd
+++ b/docs/architecture.qmd
@@ -13,7 +13,7 @@ provider classes converge on the same post-fetch stages
 `<Mission>_full_size.tiff` + `userdata.json` sidecar), so downstream
 tools never need to care which provider served the scene.
 
-```mermaid
+```{mermaid}
 flowchart TD
     U["fetch_sentinel_data(mission, bands, roi, time_range)"]
     V["validate_query"]
@@ -65,7 +65,7 @@ exposes, and how those bands map onto the provider's assets.
 `provider="auto"` picks the recommended provider per mission; a user can
 override it at call time.
 
-```mermaid
+```{mermaid}
 flowchart LR
     MP["MISSION_PROFILES (26 missions)"]
     ES["earthsearch"]


### PR DESCRIPTION
Follow-up to #25: #25 removed the HTML tags that were confusing mermaid's parser, but the Quarto docs site still doesn't render the diagrams — they show as plain source. GitHub's blob view of `docs/architecture.md` renders them fine, but Quarto is where our reviewers and users will click through from the JOSS thread and README.

## Root cause

With a plain ` ```mermaid ` fence in a `.md` file, Quarto emits `<pre class="mermaid"><code>…</code></pre>` on the page but does **not** include `mermaid.min.js` in the page's `<script>` tags. Without that script, the `<pre>` element just displays as a preformatted code block with the raw source. Quarto's mermaid engine only wires up the script when it sees the executable-diagram fence ` ```{mermaid} `, which requires the file to be `.qmd`.

## Fix

- Rename `docs/architecture.md` → `docs/architecture.qmd`.
- Switch both fenced blocks from ` ```mermaid ` to ` ```{mermaid} `.
- Update `_quarto.yml` in three places (render list, top-navbar menu entry, sidebar contents).

## Verification

Ran `quarto render --to html` on the local checkout with the fix applied:

- `<script src="../site_libs/quarto-diagram/mermaid.min.js"></script>` — **now** injected on the architecture page (was absent before).
- Both blocks emit as `<pre class="mermaid mermaid-js">…</pre>`, which the script hydrates into SVG at page load.
- 51 KB rendered HTML output; no errors from `quarto render`.

Once merged, the deployed Quarto site auto-publishes from `main` via `.github/workflows/quarto-pages.yml` — new mermaid rendering should be visible at <https://buckai-observatory.github.io/geoai-datacubes/docs/architecture.html> within ~1 min.

## Trade-off

GitHub renders ` ```mermaid ` in `.md` files but does **not** render ` ```{mermaid} ` in `.qmd` files (a `.qmd` blob view shows as plain markdown source in GitHub). The primary consumer of these diagrams is the Quarto docs site — the reply to @betolink links there — so we optimise for Quarto and accept the loss of GitHub source-view rendering.
